### PR TITLE
Test allowableTags with self-closing tags

### DIFF
--- a/test/striptags-test.js
+++ b/test/striptags-test.js
@@ -18,6 +18,13 @@ describe('striptags', function() {
         assert.equal(striptags(html), text);
     });
 
+    it('should remove self-closing tags', function() {
+        var html = 'text and an <img src="" />',
+            strippedHtml = 'text and an ';
+
+        assert.equal(striptags(html), strippedHtml);
+    });
+
     it('should leave HTML tags if specified', function() {
         var html = '<strong>lorem ipsum</strong>',
             allowedTags = '<strong>';

--- a/test/striptags-test.js
+++ b/test/striptags-test.js
@@ -112,4 +112,20 @@ describe('striptags', function() {
 
         assert.equal(striptags(html, allowedTags), text);
     });
+
+    it('should leave allowable tags regardless of ending type, when specified as an array', function() {
+        var html = '<article>lorem ipsum<br> dolor<br /> sit</article>',
+            allowedTags = ['br'],
+            text = 'lorem ipsum<br> dolor<br /> sit';
+
+        assert.equal(striptags(html, allowedTags), text);
+    });
+
+    it('should account for ending type in allowable tags when specified as a string', function() {
+        var html = '<article>lorem ipsum<br> dolor<br /> sit</article>',
+            allowedTags = '<br>',
+            text = 'lorem ipsum<br> dolor sit';
+
+        assert.equal(striptags(html, allowedTags), text);
+    });
 });


### PR DESCRIPTION
@ericnorris Thanks again for this library and for being so responsive on issue #1! Being able to pass an array will make my dependent code much neater (since previously I had to keep the tags as both an array, for other purposes, and as a string for this library).

One thing I didn't go into in issue #1, because I wanted to see if there was interest in changing the API before bogging things down with details, was how to handle self-closing tags. In a sane world, a `br` element is the same whether it's written like `<br>` or `<br/>`. Yet PHP's `allowable_tags` string requires the user to specify `"<br><br/>"` if they want both stripped.

My thinking on this, therefore, is that specifying `striptags(text, ["br"])` should be equivalent to calling `strip_tags(text, '<br><br/>')` in PHP land. The implementation you wrote already does this! 

In the process, though, it broke strict PHP compatibility, since now calling `striptags(text, "<br>")` is also equivalent to calling `striptags(text, "<br><br/>")`. 

One attitude would be to say that this doesn't matter; i.e. that `striptags(text, "<br>")` equating to `strip_tags(text, "<br><br/>")` is actually an improvement over PHP's behavior. I could buy that.

Another approach, though, would be to make an array argument behave as it does currently, but maintain strict PHP compatibility for people who go out of their way to specify `allowableTags` as a `strip_tags`-formatted string. The advantage of this is that, for people who are coming from PHP, they'll still have a guarantee of 100% compatibility. If this is the approach you want to go with, then this PR just includes some test cases for it, which also show more clearly the problem I'm talking about.
