### PR TITLE
Allow quotes to contain other quote char, eg <div attr="foo'bar">

### DIFF
--- a/src/striptags.js
+++ b/src/striptags.js
@@ -109,8 +109,8 @@ function striptags(html, allowableTags) {
                     if (inQuote == c) {
                         // end quote found
                         inQuote = false;
-                    } else {
-                        // start quote
+                    } else if (! inQuote) {
+                        // start quote only if not already in one
                         inQuote = c;
                     }
                 }

--- a/test/striptags-test.js
+++ b/test/striptags-test.js
@@ -112,4 +112,12 @@ describe('striptags', function() {
 
         assert.equal(striptags(html, allowedTags), text);
     });
+
+    it('should allow quotes within attributes', function() {
+        var html = '<article attr="foo \'bar\'">lorem <a href="#">ipsum</a></article>',
+            allowedTags = [],
+            text = 'lorem ipsum';
+
+        assert.equal(striptags(html, allowedTags), text);
+    });
 });


### PR DESCRIPTION
Hi Eric!

I was playing with striptags, and it looks like it doesn't allow quotes within quotes, eg:

```
<div onclick="alert('hello world')">foo</div>
```

Granted it's an unusual use case, but AFAIK should be valid HTML...  Thanks for taking a look!
