### PR TITLE
Explicitly defining the main entry point to the module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
         "type": "git",
         "url": "https://github.com/ericnorris/striptags.git"
     },
+    "main": "index.js",
     "homepage": "https://github.com/ericnorris/striptags",
     "bugs": "https://github.com/ericnorris/striptags/issues",
     "version": "2.0.4",


### PR DESCRIPTION
This fixes some edge compatibility issues that I had using striptags with NativeScript on Android (https://github.com/NativeScript/NativeScript). I checked and it passes all of the tests and should change almost nothing for most use cases.
