### PR TITLE
add test for stripped properties and attributes

### DIFF
--- a/test/striptags-test.js
+++ b/test/striptags-test.js
@@ -120,4 +120,12 @@ describe('striptags', function() {
 
         assert.equal(striptags(html, allowedTags), text);
     });
+
+    it('should strip the tag\'s properties and attributes', function() {
+        var html = '<a href="http://google.com" title="foo" data-id="0">Click here</a>',
+            allowedTags = [],
+            text = 'Click here';
+
+        assert.equal(striptags(html, allowedTags), text);
+    });
 });


### PR DESCRIPTION
I had a situation where I thought this `striptags` module was not properly stripping the properties or attributes from the tags (where it was stripping the outer tag, but leaving the inner properties and attributes as plaintext), so I forked the module and wrote a test to confirm the behavior. It turns out that it was a simple bug in my code, but this test should prove useful in this module, hence this pull request. 