### PR TITLE
Fix of amd module definition

### DIFF
--- a/src/striptags.js
+++ b/src/striptags.js
@@ -204,7 +204,9 @@
 
     if (typeof define === 'function' && define.amd) {
         // AMD
-        define([], striptags);
+        define([], function(){
+          return striptags;
+        });
     }
 
     else if (typeof module === 'object' && module.exports) {


### PR DESCRIPTION
This pull request fixes an error in the definition of the amd module.

When requiring the module with a module loader, e.g. RequireJS, the return value was always an empty string. The reason for this behaviour is, that the second argument of the `define` function gets executed. So, in your way, the function `striptags` was called without arguments and returned an empty string.