### PR TITLE
add symbol dependency to support android build

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "bugs": "https://github.com/ericnorris/striptags/issues",
   "version": "3.0.1",
   "devDependencies": {
+    "es6-symbol": "^3.1.1",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0"
   },

--- a/src/striptags.js
+++ b/src/striptags.js
@@ -2,6 +2,7 @@
 
 (function (global) {
 
+    const Symbol = require('es6-symbol');
     const STATE_PLAINTEXT = Symbol('plaintext');
     const STATE_HTML      = Symbol('html');
     const STATE_COMMENT   = Symbol('comment');


### PR DESCRIPTION
Myself and multiple others were receiving this [error: 'Can't find variable: Symbol'](https://github.com/mcnamee/react-native-starter-app/issues/76) when building in Android with React Native. I found a solution to fix this problem. The ES6 variable needed to be declared. Not sure if you want to use this [ES6 dependency](https://www.npmjs.com/package/es6-symbol), but it worked for me!

