### PR TITLE
added fallback to "window" for browser usage

### DIFF
--- a/src/striptags.js
+++ b/src/striptags.js
@@ -230,6 +230,6 @@
 
     else {
         // Browser
-        global.striptags = striptags;
+        (global || window).striptags = striptags;
     }
 }(this));


### PR DESCRIPTION
Hi

when I was trying to use striptags with react, webpack and babel I encountered this global is undefined error:

```
TypeError: global is undefined. striptags.js:233
	./node_modules/striptags/src/striptags.js/</< striptags.js:233
	./node_modules/striptags/src/striptags.js/< striptags.js:3
	./node_modules/striptags/src/striptags.js striptags.js:1
	__webpack_require__ bootstrap:724
	fn bootstrap:101
	./config/polyfills.js/< polyfills.js:32
	./config/polyfills.js polyfills.js:1
	__webpack_require__ bootstrap:724
	fn bootstrap:101
	0 http://localhost:3000/static/js/bundle.js:223766:1
	__webpack_require__ bootstrap:724
	<anonymní> bootstrap:791
	<anonymní> http://localhost:3000/static/js/bundle.js:1:11
```

Fallback to window fixes that and keeps code testable. Making `striptags` accessible from everywhere on page, I supposed that's what you wanted in first place?

P.S.: Thanks for great module