### PR TITLE
Replace const and let with var (support Safari 9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "src/striptags.js",
   "homepage": "https://github.com/ericnorris/striptags",
   "bugs": "https://github.com/ericnorris/striptags/issues",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "devDependencies": {
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0"

--- a/src/striptags.js
+++ b/src/striptags.js
@@ -11,19 +11,19 @@
         Symbol.nonNative = true;
     }
 
-    const STATE_PLAINTEXT = Symbol('plaintext');
-    const STATE_HTML      = Symbol('html');
-    const STATE_COMMENT   = Symbol('comment');
+    var STATE_PLAINTEXT = Symbol('plaintext');
+    var STATE_HTML      = Symbol('html');
+    var STATE_COMMENT   = Symbol('comment');
 
-    const ALLOWED_TAGS_REGEX  = /<(\w*)>/g;
-    const NORMALIZE_TAG_REGEX = /<\/?([^\s\/>]+)/;
+    var ALLOWED_TAGS_REGEX  = /<(\w*)>/g;
+    var NORMALIZE_TAG_REGEX = /<\/?([^\s\/>]+)/;
 
     function striptags(html, allowable_tags, tag_replacement) {
         html            = html || '';
         allowable_tags  = allowable_tags || [];
         tag_replacement = tag_replacement || '';
 
-        let context = init_context(allowable_tags, tag_replacement);
+        var context = init_context(allowable_tags, tag_replacement);
 
         return striptags_internal(html, context);
     }
@@ -32,7 +32,7 @@
         allowable_tags  = allowable_tags || [];
         tag_replacement = tag_replacement || '';
 
-        let context = init_context(allowable_tags, tag_replacement);
+        var context = init_context(allowable_tags, tag_replacement);
 
         return function striptags_stream(html) {
             return striptags_internal(html || '', context);
@@ -56,17 +56,17 @@
     }
 
     function striptags_internal(html, context) {
-        let allowable_tags  = context.allowable_tags;
-        let tag_replacement = context.tag_replacement;
+        var allowable_tags  = context.allowable_tags;
+        var tag_replacement = context.tag_replacement;
 
-        let state         = context.state;
-        let tag_buffer    = context.tag_buffer;
-        let depth         = context.depth;
-        let in_quote_char = context.in_quote_char;
-        let output        = '';
+        var state         = context.state;
+        var tag_buffer    = context.tag_buffer;
+        var depth         = context.depth;
+        var in_quote_char = context.in_quote_char;
+        var output        = '';
 
-        for (let idx = 0, length = html.length; idx < length; idx++) {
-            let char = html[idx];
+        for (var idx = 0, length = html.length; idx < length; idx++) {
+            var char = html[idx];
 
             if (state === STATE_PLAINTEXT) {
                 switch (char) {
@@ -188,10 +188,10 @@
     }
 
     function parse_allowable_tags(allowable_tags) {
-        let tag_set = new Set();
+        var tag_set = new Set();
 
         if (typeof allowable_tags === 'string') {
-            let match;
+            var match;
 
             while ((match = ALLOWED_TAGS_REGEX.exec(allowable_tags))) {
                 tag_set.add(match[1]);
@@ -213,7 +213,7 @@
     }
 
     function normalize_tag(tag_buffer) {
-        let match = NORMALIZE_TAG_REGEX.exec(tag_buffer);
+        var match = NORMALIZE_TAG_REGEX.exec(tag_buffer);
 
         return match ? match[1].toLowerCase() : null;
     }


### PR DESCRIPTION
Hey @ericnorris, thanks for the library, great to find a library which parses html instead of regex stripping.

We had an issue trying to use this library on our frontend.
Safari 9 is crashing with ```SyntaxError: Use of const in strict mode.```

This PR fixes the issue.

