### PR TITLE
Fix let where it should be const

### DIFF
--- a/src/striptags.js
+++ b/src/striptags.js
@@ -23,7 +23,7 @@
         allowable_tags  = allowable_tags || [];
         tag_replacement = tag_replacement || '';
 
-        let context = init_context(allowable_tags, tag_replacement);
+        const context = init_context(allowable_tags, tag_replacement);
 
         return striptags_internal(html, context);
     }
@@ -32,7 +32,7 @@
         allowable_tags  = allowable_tags || [];
         tag_replacement = tag_replacement || '';
 
-        let context = init_context(allowable_tags, tag_replacement);
+        const context = init_context(allowable_tags, tag_replacement);
 
         return function striptags_stream(html) {
             return striptags_internal(html || '', context);
@@ -56,8 +56,8 @@
     }
 
     function striptags_internal(html, context) {
-        let allowable_tags  = context.allowable_tags;
-        let tag_replacement = context.tag_replacement;
+        const allowable_tags  = context.allowable_tags;
+        const tag_replacement = context.tag_replacement;
 
         let state         = context.state;
         let tag_buffer    = context.tag_buffer;
@@ -66,7 +66,7 @@
         let output        = '';
 
         for (let idx = 0, length = html.length; idx < length; idx++) {
-            let char = html[idx];
+            const char = html[idx];
 
             if (state === STATE_PLAINTEXT) {
                 switch (char) {
@@ -213,7 +213,7 @@
     }
 
     function normalize_tag(tag_buffer) {
-        let match = NORMALIZE_TAG_REGEX.exec(tag_buffer);
+        const match = NORMALIZE_TAG_REGEX.exec(tag_buffer);
 
         return match ? match[1].toLowerCase() : null;
     }

--- a/test/striptags-test.js
+++ b/test/striptags-test.js
@@ -1,20 +1,20 @@
 'use strict';
 /* global describe, it */
 
-let assert    = require('assert');
-let fs        = require('fs');
-let vm        = require('vm');
-let striptags = require('../');
+const assert    = require('assert');
+const fs        = require('fs');
+const vm        = require('vm');
+const striptags = require('../');
 
 
 describe('striptags', function() {
     describe('#module', function() {
-        let path   = require.resolve('../');
-        let src    = fs.readFileSync(path);
-        let script = new vm.Script(src);
+        const path   = require.resolve('../');
+        const src    = fs.readFileSync(path);
+        const script = new vm.Script(src);
 
         it('should define a Node module', function() {
-            let module = { exports: {} };
+            const module = { exports: {} };
 
             script.runInNewContext({module});
 
@@ -23,7 +23,7 @@ describe('striptags', function() {
 
         it('should define an AMD module', function() {
             let module = null;
-            let define = function(module_factory) {
+            const define = function(module_factory) {
                 module = module_factory();
             };
 
@@ -35,7 +35,7 @@ describe('striptags', function() {
         });
 
         it('should define a browser global', function() {
-            let global = {};
+            const global = {};
 
             script.runInNewContext(global);
 
@@ -45,27 +45,27 @@ describe('striptags', function() {
 
     describe('with no optional parameters', function() {
         it('should not strip invalid tags', function() {
-            let text = 'lorem ipsum < a> < div>';
+            const text = 'lorem ipsum < a> < div>';
 
             assert.equal(striptags(text), text);
         });
 
         it('should remove simple HTML tags', function() {
-            let html = '<a href="">lorem <strong>ipsum</strong></a>',
+            const html = '<a href="">lorem <strong>ipsum</strong></a>',
                 text = 'lorem ipsum';
 
             assert.equal(striptags(html), text);
         });
 
         it('should remove comments', function() {
-            let html = '<!-- lorem -- ipsum -- --> dolor sit amet',
+            const html = '<!-- lorem -- ipsum -- --> dolor sit amet',
                 text = ' dolor sit amet';
 
             assert.equal(striptags(html), text);
         });
 
         it('should strip tags within comments', function() {
-            let html = '<!-- <strong>lorem ipsum</strong> --> dolor sit',
+            const html = '<!-- <strong>lorem ipsum</strong> --> dolor sit',
                 text = ' dolor sit';
 
             assert.equal(striptags(html), text);
@@ -73,7 +73,7 @@ describe('striptags', function() {
 
 
         it('should not fail with nested quotes', function() {
-            let html = '<article attr="foo \'bar\'">lorem</article> ipsum',
+            const html = '<article attr="foo \'bar\'">lorem</article> ipsum',
                 text = 'lorem ipsum';
 
             assert.equal(striptags(html), text);
@@ -82,14 +82,14 @@ describe('striptags', function() {
 
     describe('#allowed_tags', function() {
         it('should parse a string', function() {
-            let html = '<strong>lorem ipsum</strong>',
+            const html = '<strong>lorem ipsum</strong>',
                 allowed_tags = '<strong>';
 
             assert.equal(striptags(html, allowed_tags), html);
         });
 
         it('should take an array', function() {
-            let html = '<strong>lorem <em>ipsum</em></strong>',
+            const html = '<strong>lorem <em>ipsum</em></strong>',
                 allowed_tags = ['strong', 'em'];
 
             assert.equal(striptags(html, allowed_tags), html);
@@ -98,14 +98,14 @@ describe('striptags', function() {
 
     describe('with allowable_tags parameter', function() {
         it('should leave attributes when allowing HTML', function() {
-            let html = '<a href="https://example.com">lorem ipsum</a>',
+            const html = '<a href="https://example.com">lorem ipsum</a>',
                 allowed_tags = '<a>';
 
             assert.equal(striptags(html, allowed_tags), html);
         });
 
         it('should strip extra < within tags', function() {
-            let html = '<div<>>lorem ipsum</div>',
+            const html = '<div<>>lorem ipsum</div>',
                 text = '<div>lorem ipsum</div>',
                 allowed_tags = '<div>';
 
@@ -113,7 +113,7 @@ describe('striptags', function() {
         });
 
         it('should strip <> within quotes', function() {
-            let html = '<a href="<script>">lorem ipsum</a>',
+            const html = '<a href="<script>">lorem ipsum</a>',
                 text = '<a href="script">lorem ipsum</a>',
                 allowed_tags = '<a>';
 
@@ -134,11 +134,11 @@ describe('striptags', function() {
 
     describe('#streaming_mode', function() {
         it('should strip streamed HTML', function() {
-            let striptags_stream = striptags.init_streaming_mode();
+            const striptags_stream = striptags.init_streaming_mode();
 
-            let part_one   = striptags_stream('lorem ipsum <stro');
-            let part_two   = striptags_stream('ng>dolor sit <');
-            let part_three = striptags_stream(' amet');
+            const part_one   = striptags_stream('lorem ipsum <stro');
+            const part_two   = striptags_stream('ng>dolor sit <');
+            const part_three = striptags_stream(' amet');
 
             assert.equal(part_one, 'lorem ipsum ');
             assert.equal(part_two, 'dolor sit ');
@@ -146,11 +146,11 @@ describe('striptags', function() {
         });
 
         it('should work with allowable_tags', function() {
-            let striptags_stream = striptags.init_streaming_mode(['strong']);
+            const striptags_stream = striptags.init_streaming_mode(['strong']);
 
-            let part_one   = striptags_stream('lorem ipsum <stro');
-            let part_two   = striptags_stream('ng>dolor sit <');
-            let part_three = striptags_stream(' amet');
+            const part_one   = striptags_stream('lorem ipsum <stro');
+            const part_two   = striptags_stream('ng>dolor sit <');
+            const part_three = striptags_stream(' amet');
 
             assert.equal(part_one, 'lorem ipsum ');
             assert.equal(part_two, '<strong>dolor sit ');


### PR DESCRIPTION
We found that the latest striptags introduces es6, but not completely. This pr updates the code to use const where appropriate.

- [x] using lint prefer-const rule in #58, auto fix all instances of let which are not re-assigned

