### PR TITLE
feat: add default export

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     },
     "homepage": "https://github.com/ericnorris/striptags",
     "bugs": "https://github.com/ericnorris/striptags/issues",
-    "version": "4.0.0-alpha.2",
+    "version": "4.0.0-alpha.3",
     "keywords": [
         "striptags",
         "strip_tags",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,6 +19,7 @@ export default [
             {
                 format: "cjs",
                 dir: "dist/cjs",
+                exports: "named",
             },
         ],
         plugins: [typescript()],

--- a/src/striptags.ts
+++ b/src/striptags.ts
@@ -37,3 +37,5 @@ export class StateMachine {
 export function striptags(text: string, options: Partial<StateMachineOptions> = {}): string {
     return new StateMachine(options).consume(text);
 }
+
+export default striptags;


### PR DESCRIPTION
The `README` calls out to import `striptags` via `import { striptags } from "striptags"`, but it's easy enough to miss and it's reasonable to expect that `import striptags from striptags` would work. Exporting `striptags` as the ["default export"](https://www.typescriptlang.org/docs/handbook/modules.html#default-exports) should solve this by making it directly importable.

Fixes: #72.